### PR TITLE
Multi-monitor support

### DIFF
--- a/src/hyprland/ipc.cpp
+++ b/src/hyprland/ipc.cpp
@@ -22,9 +22,7 @@ namespace hyprland {
 
     // Control
     Control::Control() : Control(getSocketPath(".socket.sock")) {}
-    Control::Control(const std::string& socketPath) : socketPath(socketPath) {
-        detectLuaProtocol();
-    }
+    Control::Control(const std::string& socketPath) : socketPath(socketPath) { detectLuaProtocol(); }
 
     Control::~Control() {}
 
@@ -88,6 +86,42 @@ namespace hyprland {
         return {(float)x, (float)y};
     }
 
+    std::vector<Monitor> Control::getMonitors() {
+        std::vector<Monitor> result;
+        std::string response = send("j/monitors");
+        try {
+            auto node = YAML::Load(response);
+            if (node.IsSequence()) {
+                for (const auto& m : node) {
+                    Monitor monitor;
+                    monitor.id = m["id"].as<int>();
+                    monitor.name = m["name"].as<std::string>();
+                    monitor.x = m["x"].as<int>();
+                    monitor.y = m["y"].as<int>();
+                    monitor.width = m["width"].as<int>();
+                    monitor.height = m["height"].as<int>();
+                    monitor.scale = m["scale"].as<float>();
+                    monitor.focused = m["focused"].as<bool>();
+                    result.push_back(monitor);
+                }
+            }
+        } catch (const std::exception& e) {
+            debug::log(ERR, "Failed to parse monitors: {}", e.what());
+        }
+        return result;
+    }
+
+    Monitor hyprland::Control::monitorAtCursor() {
+        Vec2 cursor = cursorPos();
+        auto monitors = getMonitors();
+        for (auto& m : monitors) {
+            if (cursor.x >= m.x && cursor.x < m.x + m.width && cursor.y >= m.y && cursor.y < m.y + m.height) {
+                return m;
+            }
+        }
+        return monitors[0]; // fallback
+    }
+
     float Control::scale() {
         std::string response = send("monitors");
 
@@ -105,7 +139,8 @@ namespace hyprland {
 
     void Control::setWallpaper(const std::string& path) {
         if (luaProtocol) {
-            std::string response = send("/dispatch hl.dsp.exec_cmd(\"hyprctl hyprpaper preload \\\"" + path + "\\\"\")");
+            std::string response =
+                send("/dispatch hl.dsp.exec_cmd(\"hyprctl hyprpaper preload \\\"" + path + "\\\"\")");
             if (response != "ok") {
                 debug::log(ERR, "Failed to preload wallpaper: {}", response);
             }

--- a/src/hyprland/ipc.hpp
+++ b/src/hyprland/ipc.hpp
@@ -3,8 +3,8 @@
 #include "../vec.hpp"
 #include <atomic>
 #include <functional>
-#include <string>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -30,6 +30,18 @@ namespace hyprland {
         bool mapped = false;
         bool hidden = false;
     };
+
+    struct Monitor {
+        int id;
+        std::string name;
+        int x;
+        int y;
+        int width;
+        int height;
+        float scale;
+        bool focused;
+    };
+
     class Control {
     public:
         explicit Control();
@@ -40,8 +52,10 @@ namespace hyprland {
         std::string send(const std::string& command);
 
         // these are in fractional scale pixels
-        Vec2 cursorPos();
         float scale();
+        Vec2 cursorPos();
+        std::vector<Monitor> getMonitors();
+        Monitor monitorAtCursor();
 
         void setWallpaper(const std::string& path);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,16 +98,26 @@ int main(const int argc, const char** argv) {
     hyprland::Control hyprctl;
     Vec2 pos = hyprctl.cursorPos();
 
-    // deal with hyprland fractional scaling vs wayland integer scaling
-    float hyprlandScale = hyprctl.scale();
-    int waylandScale = wayland.display().getMaxScale();
-    auto [displayWidth, displayHeight] = wayland.display().getOutputSize();
+    // Get the monitor the cursor is currently on
+    auto monitor = hyprctl.monitorAtCursor();
+    float hyprlandScale = monitor.scale;
 
-    // convert hyprland logical->physical->wayland logical
-    int x_physical = (int)(pos.x * hyprlandScale);
-    int y_physical = (int)(pos.y * hyprlandScale);
+    // global offset of this monitor
+    int monitorOffsetX = monitor.x;
+    int monitorOffsetY = monitor.y;
+
+    // cursor position local to this monitor in hyprland logical
+    float localX = pos.x - monitorOffsetX;
+    float localY = pos.y - monitorOffsetY;
+
+    // convert hyprland logical to physical to wayland logical
+    int waylandScale = wayland.display().getMaxScale();
+    int x_physical = (int)(localX * hyprlandScale);
+    int y_physical = (int)(localY * hyprlandScale);
     int x_wayland = x_physical / waylandScale;
     int y_wayland = y_physical / waylandScale;
+
+    auto [displayWidth, displayHeight] = wayland.display().getOutputSize();
     int logicalDisplayWidth = displayWidth / hyprlandScale;
     int logicalDisplayHeight = displayHeight / hyprlandScale;
 
@@ -115,7 +125,7 @@ int main(const int argc, const char** argv) {
     Config config("~/.config/hyprwat/hyprwat.conf");
 
     // initialize UI at wayland scaled cursor position
-    ui.init(pos.x, pos.y, hyprlandScale);
+    ui.init(x_wayland, y_wayland, hyprlandScale);
 
     // apply theme to UI
     ui.applyTheme(config);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,8 +98,13 @@ int main(const int argc, const char** argv) {
     hyprland::Control hyprctl;
     Vec2 pos = hyprctl.cursorPos();
 
-    // Get the monitor the cursor is currently on
+    // get the monitor the cursor is currently on
     auto monitor = hyprctl.monitorAtCursor();
+    if (monitor.id < 0) {
+        debug::log(ERR, "Failed to find monitor at cursor, aborting");
+        return 1;
+    }
+
     float hyprlandScale = monitor.scale;
 
     // global offset of this monitor
@@ -118,8 +123,6 @@ int main(const int argc, const char** argv) {
     int y_wayland = y_physical / waylandScale;
 
     auto [displayWidth, displayHeight] = wayland.display().getOutputSize();
-    int logicalDisplayWidth = displayWidth / hyprlandScale;
-    int logicalDisplayHeight = displayHeight / hyprlandScale;
 
     // load config
     Config config("~/.config/hyprwat/hyprwat.conf");
@@ -157,10 +160,10 @@ int main(const int argc, const char** argv) {
         flow = std::make_unique<CustomFlow>(args.configPath);
         break;
     case InputMode::OVERVIEW:
-        flow = std::make_unique<OverviewFlow>(hyprctl, wayland.display(), logicalDisplayWidth, logicalDisplayHeight);
+        flow = std::make_unique<OverviewFlow>(hyprctl, wayland.display(), monitor.width, monitor.height);
         break;
     case InputMode::WALLPAPER:
-        flow = std::make_unique<WallpaperFlow>(hyprctl, args.wallpaperDir, logicalDisplayWidth, logicalDisplayHeight);
+        flow = std::make_unique<WallpaperFlow>(hyprctl, args.wallpaperDir, monitor.width, monitor.height);
         break;
     case InputMode::MENU:
         if (args.choices.size() > 0) {


### PR DESCRIPTION
Fixes #14 

Multi-monitor support was completely broken for finding the cursor position. The values returned by `hyprctl cursorPos` are hypland global space, so we have to use the monitor dimensions to offset the position.